### PR TITLE
[feat] 모바일 반응형 헤더 및 메뉴바 구현

### DIFF
--- a/public/assets/hamburger.svg
+++ b/public/assets/hamburger.svg
@@ -1,0 +1,5 @@
+<svg width="22" height="20" viewBox="0 0 22 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 3H21" stroke="#994C00" stroke-width="2" stroke-linecap="round"/>
+<path d="M1 10H21" stroke="#994C00" stroke-width="2" stroke-linecap="round"/>
+<path d="M1 17H21" stroke="#994C00" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -8,6 +8,7 @@ interface Props {
   heightValue: string | number;
   colorValue: string;
   text: string;
+  type: string;
   className?: string;
   onClick?: () => void;
 }
@@ -19,6 +20,7 @@ export function Button({
   heightValue,
   colorValue,
   text,
+  type = 'button',
   className,
   onClick,
 }: Props) {
@@ -30,7 +32,7 @@ export function Button({
 
   return (
     <button
-      type="button"
+      type={type}
       aria-label={text + ' 버튼'}
       className={classNames(
         className,

--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -1,8 +1,24 @@
+@import '@/styles/common/index.scss';
+
 .header {
   padding: 30px;
   display: flex;
   justify-content: space-between;
+  align-items: center;
   font-weight: 700;
   font-size: 1.25rem;
   color: var(--colar-700);
+
+  @include tablet {
+    font-size: 1rem;
+    padding: 30px 7px;
+    display: flex;
+    align-items: center;
+  }
+  @include mobile {
+    display: flex;
+    justify-content: space-between;
+    padding: 30px 10px;
+    align-items: center;
+  }
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -2,14 +2,22 @@ import { LogoIconandText } from '@/components/LogoIconandText/LogoIconandText';
 import { Link } from 'react-router-dom';
 import { Nav } from '@/components/Nav/Nav';
 import classes from './Header.module.scss';
+import { useSetRecoilState } from 'recoil';
+import { isActive } from '@/states/isActive';
 
 export function Header() {
+  const setActive = useSetRecoilState(isActive);
+
+  const clickHamburger = () => {
+    setActive((current) => !current);
+  };
+
   return (
     <header className={classes.header}>
-      <Link to="/">
+      <Link to="/mainPage">
         <LogoIconandText small={true} />
       </Link>
-      <Nav />
+      <Nav onClick={clickHamburger} />
     </header>
   );
 }

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -15,7 +15,6 @@ interface Props {
 }
 
 export function Input({
-  type,
   maxWidthValue,
   heightValue,
   labelText,

--- a/src/components/Input/SearchForm.tsx
+++ b/src/components/Input/SearchForm.tsx
@@ -3,6 +3,7 @@ import { Input } from './Input';
 import { InputSelector } from '../InputSelector/InputSelector';
 import { Button } from '../Button';
 import { ModalTotal } from '@/components/index';
+import { useNavigate } from 'react-router-dom';
 
 export function SearchFrom({
   setTitle,
@@ -11,6 +12,12 @@ export function SearchFrom({
   createUsers,
   getUsers,
 }) {
+  const movePage = useNavigate();
+
+  const goChatPage = () => {
+    movePage('/chat');
+  };
+
   return (
     <>
       <div className={classes['InputContainer']}>
@@ -41,6 +48,7 @@ export function SearchFrom({
             text="채팅 하기"
             backgroundColor={'orange'}
             className={classes.ChatButton}
+            onClick={goChatPage}
           />
         </div>
       </div>

--- a/src/components/InputSelector/InputSelector.module.scss
+++ b/src/components/InputSelector/InputSelector.module.scss
@@ -5,4 +5,5 @@
   padding: 1rem 0.75rem;
   width: 100%;
   text-align: center;
+  cursor: pointer;
 }

--- a/src/components/LogoIconandText/LogoIconandText.module.scss
+++ b/src/components/LogoIconandText/LogoIconandText.module.scss
@@ -1,7 +1,6 @@
 .logoIconandText {
   display: flex;
   align-items: center;
-  
 }
 .logoIconandText > img {
   margin-top: 8px;
@@ -10,7 +9,7 @@
 
 .logoTextSmall {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
 }
 
 .logoTextSmall > img{
@@ -18,3 +17,4 @@
   height: 25px;
   padding-right: 5px;
 }
+

--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -121,6 +121,7 @@
   height: 50px;
   color: red;
   vertical-align: middle;
+  cursor: pointer;
 }
 
 .signupButton {

--- a/src/components/Modal/ModalTotal.tsx
+++ b/src/components/Modal/ModalTotal.tsx
@@ -103,6 +103,7 @@ export function ModalTotal({
                   widthValue={300}
                   heightValue={50}
                   text={'모임 만들기'}
+                  type={'submit'}
                   backgroundColor={'orange'}
                   className={classes.signupButton}
                   onClick={handleRegister}

--- a/src/components/Nav/Nav.module.scss
+++ b/src/components/Nav/Nav.module.scss
@@ -1,14 +1,77 @@
+@import '@/styles/common/index.scss';
+
 .nav {
   display: flex;
+
+  ul {
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+  }
+  li {
+    padding: 0 10px;
+    
+    &:last-child {
+      padding-right: 0;
+    }
+  
+    @include tablet {
+      padding: 0 0.2rem;
+      font-size: 0.93rem;
+      font-weight: 800;
+    }
+    @include mobile {
+      display: none;
+    }
+  }
 }
 
-.nav > div {
-  padding: 0 10px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
+
+
+.hamburger {
+  display: none;
+
+  @include mobile {
+    display: flex;
+    justify-content: flex-end;
+    width: 3vw;
+    height: 3vh;
+  }
 }
-.nav > div:last-child {
-  padding-right: 0;
+
+.open {
+  z-index: 10;
+  transition: all .2s ease;
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 100px;
+  padding: 30px;
+  background-color: var(--secondary);
+
+  li {
+    padding: 15px 0;
+
+    &:last-child {
+      font-size: 83%;
+
+      span {
+        font-size: 115%;
+      }
+    }
+    &:hover {
+      text-decoration: underline;
+      color: var(--positive);
+    }
+  }
+
+  img {
+    width: 80%;
+    height: 80%;
+    padding-top: 30px;
+}
+}
+
+.closeHidden {
+  display: none;
 }

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -1,21 +1,50 @@
 import { NavLink } from 'react-router-dom';
 import classes from './Nav.module.scss';
+import { useRecoilState } from 'recoil';
+import { isActive } from '@/states/isActive';
 
-export function Nav() {
+export function Nav({ onClick }) {
+  const [active, setActive] = useRecoilState(isActive);
+
   return (
-    <nav className={classes.nav}>
-      <div>
-        <NavLink to="/mainPage">홈</NavLink>
+    <div>
+      <nav
+        className={active ? classes.open : classes.nav}
+        onMouseLeave={() => setActive(false)}
+      >
+        <ul>
+          <li>
+            <NavLink to="/mainPage">홈</NavLink>
+          </li>
+          <li>
+            <NavLink to="/recommend">추천</NavLink>
+          </li>
+          <li>
+            <NavLink to="/chat">채팅</NavLink>
+          </li>
+          <li>
+            <NavLink to="/myPage">
+              <span>마이</span>페이지
+            </NavLink>
+          </li>
+        </ul>
+        <button
+          type="button"
+          className={active ? null : classes.closeHidden}
+          onClick={() => setActive(false)}
+        >
+          <img
+            className={classes.closeImg}
+            src="/public/assets/close.svg"
+            alt="메뉴닫기"
+          />
+        </button>
+      </nav>
+      <div className={active ? classes.nav : classes.hamburger}>
+        <button type="button" onClick={onClick}>
+          <img src="/public/assets/hamburger.svg" alt="메뉴" />
+        </button>
       </div>
-      <div>
-        <NavLink to="/recommend">추천</NavLink>
-      </div>
-      <div>
-        <NavLink to="/chat">채팅</NavLink>
-      </div>
-      <div>
-        <NavLink to="/myPage">마이페이지</NavLink>
-      </div>
-    </nav>
+    </div>
   );
 }

--- a/src/states/isActive.ts
+++ b/src/states/isActive.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const isActive = atom({
+  key: 'isActive',
+  default: false,
+});


### PR DESCRIPTION
#65 #66 
#67 
✨ 구현 기능 명세
- 헤더 반응형(모바일) 구현 : 햄버거 바 생성, 햄버거 바 클릭시 메뉴 펼치기  
- 모바일 -> 채팅하기 버튼 클릭시 채팅하기 페이지로 이동 = useNavigate 이용

🎁 PR Point
반응형이 잘 되는지, 시멘틱 마크업 잘 되었는지 체크

😭 어려웠던 점
- 메뉴 펼친 뒤, 나갈때 X가 svg파일 이었는데, fill이 적용이 되지 않았다. 
여러가지 방법을 시도하였으나 왜 안되는지 잘 모르겠다. 야무쌤 이슈에 올릴예정이다.