### PR TITLE
[feat] Card 클릭시 팝업창에 해당 데이터 지도 정보 불러오기

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -8,7 +8,7 @@ interface Props {
   heightValue: string | number;
   labelText: string;
   placeHolder?: string;
-  isA11yHidden: boolean;
+  isA11yHidden?: boolean;
   className?: string;
   type?: string;
   onChange?: DebouncedFunc<() => void>;

--- a/src/components/InputSelector/InputSelector.tsx
+++ b/src/components/InputSelector/InputSelector.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-unused-vars */
 import classes from './InputSelector.module.scss';
 import classNames from 'classnames';
+import { addressState } from '@/states/addressState';
+import { useRecoilState } from 'recoil';
 
 interface Props {
   maxWidthValue: number;
@@ -23,6 +25,8 @@ export function InputSelector({
     className: className,
     marginBottom: marginBottom,
   };
+
+  const [address, setAddress] = useRecoilState(addressState);
 
   const location = [
     {
@@ -149,7 +153,8 @@ export function InputSelector({
       onClick={(e) => {
         for (let i = 0; i < location.length; i++) {
           if ((e.target as HTMLButtonElement).value === location[i].value) {
-            console.log(location[i].address);
+            setAddress(location[i].address);
+            console.log(address);
           }
         }
       }}

--- a/src/components/Modal/ModalTotal.tsx
+++ b/src/components/Modal/ModalTotal.tsx
@@ -14,7 +14,6 @@ import { debounce } from 'lodash';
 import { useSetRecoilState } from 'recoil';
 import { cardDataState } from './../../states/cardDataState';
 import React from 'react';
-//import { Form } from './Form';
 
 export function ModalTotal({
   createUsers,
@@ -32,11 +31,11 @@ export function ModalTotal({
     setModalOpened(true);
   };
 
-  const handleRegister = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const handleRegister = () => {
     setModalOpened(false);
     createUsers();
     getUsers();
+    alert('모임이 작성되었습니다.');
   };
 
   const handleClose = () => {

--- a/src/components/Modal/ReadMeetings.tsx
+++ b/src/components/Modal/ReadMeetings.tsx
@@ -7,7 +7,7 @@ import { collection, getDocs, query, where } from '@firebase/firestore';
 import firebase from 'firebase/compat/app';
 import 'firebase/compat/auth';
 import 'firebase/compat/firestore';
-import { Suspense } from 'react';
+import { MapReading } from '@/utils/MapReading';
 
 interface Props {
   openModal: boolean;
@@ -47,45 +47,48 @@ export const ReadMeetings = ({ openModal, setOpenModal }: Props) => {
 
   const showUsers = users.map((value, index) => (
     <div key={index} className={classes.showUsers}>
+      <MapReading mapPosition={value.mapData} />
       <span>{value.title}</span>
       <span>{value.address}</span>
-      <span> {value.detail}</span>
-      <span> {value.cardData.slice(0, 15)}</span>
+      <span>{value.detail}</span>
+      <span>{value.cardData.slice(0, 15)}</span>
       <span className={classes.lastSpan}> {value.cardData.slice(16)}</span>
     </div>
   ));
 
   return (
     <div>
-      <Suspense fallback={<div role="alert">LOADING...</div>}>
-        {openModal && (
-          <ModalPotal closePortal={handleClose}>
-            <Modal>
-              <h2 className={classes.popupTitle}>모임 만들기</h2>
-              <div className={classes.popupContent}>
-                <MapContainer />
+      {openModal && (
+        <ModalPotal closePortal={handleClose}>
+          <Modal>
+            <div className={classes.popupContent}>
+              <MapContainer />
 
-                <form
-                  onSubmit={handleRegister}
-                  className={classes['modalForm']}
-                >
-                  <div className={classes['modalSearch']}>
-                    {showUsers}
-                    <Button
-                      maxWidthValue={300}
-                      heightValue={50}
-                      text={'탈퇴하기'}
-                      backgroundColor={'red'}
-                      className={classes.signupButton}
-                      onClick={handleRegister}
-                    />
-                  </div>
-                </form>
-              </div>
-            </Modal>
-          </ModalPotal>
-        )}
-      </Suspense>
+              <form onSubmit={handleRegister} className={classes['modalForm']}>
+                <div className={classes['modalSearch']}>
+                  {showUsers}
+                  <Button
+                    maxWidthValue={300}
+                    heightValue={50}
+                    text={'탈퇴하기'}
+                    backgroundColor={'red'}
+                    className={classes.signupButton}
+                    onClick={handleRegister}
+                  />
+                  <Button
+                    maxWidthValue={300}
+                    heightValue={50}
+                    text={'삭제하기'}
+                    backgroundColor={'red'}
+                    className={classes.signupButton}
+                    onClick={handleRegister}
+                  />
+                </div>
+              </form>
+            </div>
+          </Modal>
+        </ModalPotal>
+      )}
     </div>
   );
 };

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -12,8 +12,9 @@ import {
   orderBy,
 } from '@firebase/firestore';
 import { useState, useEffect } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useRecoilState } from 'recoil';
 import { cardDataState } from './../../states/cardDataState';
+import { mapState } from '@/states/mapState';
 
 export default function MainPage() {
   const [title, setTitle] = useState('');
@@ -21,6 +22,8 @@ export default function MainPage() {
   const [detail, setDetail] = useState('');
 
   const cardData = useRecoilValue(cardDataState);
+  const [mapData, setMapData] = useRecoilState(mapState);
+  console.log(typeof mapData);
 
   const [users, setUsers] = useState([]);
 
@@ -37,7 +40,7 @@ export default function MainPage() {
 
   useEffect(() => {
     getUsers();
-  }, [cardData]);
+  }, [mapData]);
 
   const createUsers = async () => {
     await addDoc(collection(db, 'makeMeetings'), {
@@ -45,6 +48,7 @@ export default function MainPage() {
       address: address,
       detail: detail,
       cardData: cardData,
+      mapData: mapData,
       timestamp: serverTimestamp(),
     });
   };

--- a/src/states/addressState.ts
+++ b/src/states/addressState.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const addressState = atom({
+  key: 'addressState',
+  default: '',
+});

--- a/src/states/mapState.ts
+++ b/src/states/mapState.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const mapState = atom({
+  key: 'mapState',
+  default: [0, 0],
+});

--- a/src/states/readingMap.ts
+++ b/src/states/readingMap.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const readingMap = atom({
+  key: 'readingMap',
+  default: [33.450701, 126.570667],
+});

--- a/src/utils/MapContainer.tsx
+++ b/src/utils/MapContainer.tsx
@@ -1,25 +1,53 @@
 /*global kakao*/
 import React, { useEffect } from 'react';
 import classes from './MapContainer.module.scss';
+import { useRecoilValue, useRecoilState } from 'recoil';
+import { addressState } from '@/states/addressState';
+import { mapState } from '@/states/mapState';
+import { readingMap } from '@/states/readingMap';
 
 const { kakao } = window;
 
 export const MapContainer = () => {
+  const address = useRecoilValue(addressState);
+  const [mapLocation, setMapLocation] = useRecoilState(mapState);
+  const mapData = useRecoilValue(readingMap);
+
+  console.log('mapData', mapData);
   useEffect(() => {
     const mapContainer = document.getElementById('map'); // 지도를 표시할 div
     const mapOption = {
-      center: new kakao.maps.LatLng(37.365264512305174, 127.10676860117488), // 지도의 중심좌표
+      center: new kakao.maps.LatLng(mapData[0], mapData[1]), // 지도의 중심좌표
       level: 3, // 지도의 확대 레벨
     };
 
     // 지도를 생성합니다
     const map = new kakao.maps.Map(mapContainer, mapOption);
 
+    // 마커가 표시될 위치입니다
+    const markerPosition = new kakao.maps.LatLng(mapData[0], mapData[1]);
+
+    // 마커를 생성합니다
+    const Firstmarker = new kakao.maps.Marker({
+      position: markerPosition,
+    });
+
+    // 마커가 지도 위에 표시되도록 설정합니다
+    Firstmarker.setMap(map);
+  }, [address, setMapLocation, mapData]);
+
+  useEffect(() => {
+    const mapContainer = document.getElementById('map'); // 지도를 표시할 div
+    const mapOption = {
+      center: new kakao.maps.LatLng(mapData[0], mapData[1]), // 지도의 중심좌표
+      level: 3, // 지도의 확대 레벨
+    };
     // 주소-좌표 변환 객체를 생성합니다
     const geocoder = new kakao.maps.services.Geocoder();
+    const map = new kakao.maps.Map(mapContainer, mapOption);
 
     // 주소로 좌표를 검색합니다
-    geocoder.addressSearch('독산로45가길 10', function (result, status) {
+    geocoder.addressSearch(`${address}`, function (result, status) {
       // 정상적으로 검색이 완료됐으면
       if (status === kakao.maps.services.Status.OK) {
         const coords = new kakao.maps.LatLng(result[0].y, result[0].x);
@@ -30,10 +58,12 @@ export const MapContainer = () => {
 
           // 마커 위치를 클릭한 위치로 옮깁니다
           marker.setPosition(latlng);
-
           let message = '클릭한 위치의 위도는 ' + latlng.getLat() + ' 이고, ';
           message += '경도는 ' + latlng.getLng() + ' 입니다';
           console.log(message);
+
+          setMapLocation([latlng.getLat(), latlng.getLng()]);
+          console.log('mapConainer파일안', map);
         });
         // 결과값으로 받은 위치를 마커로 표시합니다
         const marker = new kakao.maps.Marker({
@@ -42,9 +72,10 @@ export const MapContainer = () => {
         });
         // 지도의 중심을 결과값으로 받은 위치로 이동시킵니다
         map.setCenter(coords);
+        marker.setMap(map);
       }
     });
-  }, []);
+  }, [address]);
 
   return (
     <div className={classes['mapContainer']}>

--- a/src/utils/MapReading.tsx
+++ b/src/utils/MapReading.tsx
@@ -1,0 +1,10 @@
+import { useSetRecoilState } from 'recoil';
+import { readingMap } from '@/states/readingMap';
+
+export function MapReading({ mapPosition }) {
+  console.log('MapReading파일', mapPosition);
+  const setMapData = useSetRecoilState(readingMap);
+  setMapData(mapPosition);
+
+  return <></>;
+}


### PR DESCRIPTION
#106 
✨ 구현 기능 명세
MainPage ->  mapData: mapData create되게함   
ReadMeetings -> 해당데이터를 가져옴   
MapReading -> 해당데이터 전달 통로 역할(map함수는 값을 받지못해 컴포넌트의 프롭스로 일단 받아옴)   
MapContainer -> recoil를 이용한 atom을 통해 받아온 데이터로 주소값을 재설정해줌,   
                            경우마다 다른 랜더링이 많이 필요해서 useEffect 다수 사용
🎁 PR Point
지도 리랜더링 시점 확인

😭 어려웠던 점
map함수안에 값이 안들어가져서 컴포넌트를 만든뒤 전달하여 값을 전달해주었다.
<MapReading mapPosition={value.mapData} />

지도가 클릭할때 해당 데이터를 리랜더링 시켜야하는 작업이 많았어서
useEffect를 많이 사용하였는데, dependency Array값을 넣어주는데에 생각을 많이하는 계기가 되었다.