### PR TITLE
[feat] fireStore 삭제 기능 & 화면 렌더링 동기화 구현

### DIFF
--- a/src/components/Modal/ReadMeetings.tsx
+++ b/src/components/Modal/ReadMeetings.tsx
@@ -3,21 +3,36 @@ import { MapContainer } from './../../utils/MapContainer';
 import { Button, ModalPotal, Modal } from '@/components/index';
 import classes from './Modal.module.scss';
 import { useState, useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+import { deleteUsers } from '@/states/deleteUsers';
 import { db } from '@/firebase/firestore/index';
-import { collection, getDocs, query, where } from '@firebase/firestore';
+import {
+  collection,
+  getDocs,
+  query,
+  where,
+  orderBy,
+} from '@firebase/firestore';
 import firebase from 'firebase/compat/app';
 import 'firebase/compat/auth';
 import 'firebase/compat/firestore';
-import { MapReading } from '@/utils/MapReading';
+import React from 'react';
+import { usersState } from '@/states/usersState';
+
+const ShowCard = React.lazy(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  return import('./showCard');
+});
 
 interface Props {
   openModal: boolean;
   // eslint-disable-next-line no-unused-vars
   setOpenModal: (p: boolean) => void;
 }
-
 export const ReadMeetings = ({ openModal, setOpenModal }: Props) => {
-  const [users, setUsers] = useState([]);
+  const [users, setUsers] = useRecoilState(usersState);
+  const [deleteCard, setDeleteCard] = useRecoilState(deleteUsers);
+  const [cards, setCards] = useState([]);
 
   const usersCollectionRef = query(
     collection(db, 'makeMeetings'),
@@ -28,8 +43,20 @@ export const ReadMeetings = ({ openModal, setOpenModal }: Props) => {
     )
   );
 
+  const usersCollectionRenderRef = query(
+    collection(db, 'makeMeetings'),
+    orderBy('timestamp', 'desc')
+  );
+
   const getUsers = async () => {
     await getDocs(usersCollectionRef).then((data) => {
+      setCards(data.docs.map((doc) => ({ ...doc.data(), id: doc.id })));
+    });
+  };
+  console.log('cards', cards);
+
+  const getAfterDelete = async () => {
+    await getDocs(usersCollectionRenderRef).then((data) => {
       setUsers(data.docs.map((doc) => ({ ...doc.data(), id: doc.id })));
     });
   };
@@ -38,24 +65,15 @@ export const ReadMeetings = ({ openModal, setOpenModal }: Props) => {
     getUsers();
   }, []);
 
-  // const handleRegister = () => {
-  //   setOpenModal(false);
-  // };
-
   const handleClose = () => {
     setOpenModal(false);
   };
 
-  const showUsers = users.map((value, index) => (
-    <div key={index} className={classes.showUsers}>
-      <MapReading mapPosition={value.mapData} />
-      <span>{value.title}</span>
-      <span>{value.address}</span>
-      <span>{value.detail}</span>
-      <span>{value.cardData.slice(0, 15)}</span>
-      <span className={classes.lastSpan}> {value.cardData.slice(16)}</span>
-    </div>
-  ));
+  const handleDelete = () => {
+    setOpenModal(false);
+    deleteCard(localStorage.getItem('Unique ID'));
+    getAfterDelete();
+  };
 
   return (
     <div>
@@ -67,7 +85,9 @@ export const ReadMeetings = ({ openModal, setOpenModal }: Props) => {
 
               <form onSubmit={handleClose} className={classes['modalForm']}>
                 <div className={classes['modalSearch']}>
-                  {showUsers}
+                  <React.Suspense fallback={<div>로딩 중...</div>}>
+                    <ShowCard cards={cards} />
+                  </React.Suspense>
                   <Button
                     maxWidthValue={300}
                     heightValue={50}
@@ -82,7 +102,7 @@ export const ReadMeetings = ({ openModal, setOpenModal }: Props) => {
                     text={'삭제하기'}
                     backgroundColor={'red'}
                     className={classes.signupButton}
-                    onClick={handleClose}
+                    onClick={handleDelete}
                   />
                 </div>
               </form>

--- a/src/components/Modal/ReadMeetings.tsx
+++ b/src/components/Modal/ReadMeetings.tsx
@@ -69,10 +69,11 @@ export const ReadMeetings = ({ openModal, setOpenModal }: Props) => {
     setOpenModal(false);
   };
 
-  const handleDelete = () => {
+  const handleDelete = async () => {
     setOpenModal(false);
-    deleteCard(localStorage.getItem('Unique ID'));
+    await deleteCard(localStorage.getItem('Unique ID'));
     getAfterDelete();
+    console.log('작동한다');
   };
 
   return (
@@ -88,14 +89,6 @@ export const ReadMeetings = ({ openModal, setOpenModal }: Props) => {
                   <React.Suspense fallback={<div>로딩 중...</div>}>
                     <ShowCard cards={cards} />
                   </React.Suspense>
-                  <Button
-                    maxWidthValue={300}
-                    heightValue={50}
-                    text={'탈퇴하기'}
-                    backgroundColor={'red'}
-                    className={classes.signupButton}
-                    onClick={handleClose}
-                  />
                   <Button
                     maxWidthValue={300}
                     heightValue={50}

--- a/src/components/Modal/ShowCard.tsx
+++ b/src/components/Modal/ShowCard.tsx
@@ -1,0 +1,15 @@
+import { MapReading } from '@/utils/MapReading';
+import classes from './Modal.module.scss';
+
+export default function ShowCard({ cards }) {
+  return cards.map((value, index: number) => (
+    <div key={index} className={classes.showUsers}>
+      <MapReading mapPosition={value.mapData} />
+      <span>{value.title}</span>
+      <span>{value.addres}</span>
+      <span>{value.detail}</span>
+      <span>{value.cardData.slice(0, 15)}</span>
+      <span className={classes.lastSpan}> {value.cardData.slice(16)}</span>
+    </div>
+  ));
+}

--- a/src/components/Modal/ShowMeetings.tsx
+++ b/src/components/Modal/ShowMeetings.tsx
@@ -2,9 +2,12 @@ import { Card, Meeting } from '@/components/index';
 import classes from './Modal.module.scss';
 import { useState } from 'react';
 import { ReadMeetings } from './ReadMeetings';
+import { useRecoilState } from 'recoil';
+import { usersState } from '@/states/usersState';
 
 // eslint-disable-next-line react/prop-types
-export function ShowMeetings({ users }) {
+export function ShowMeetings() {
+  const [users, setUsers] = useRecoilState(usersState);
   const [openModal, setOpenModal] = useState(false);
 
   return (
@@ -17,6 +20,7 @@ export function ShowMeetings({ users }) {
             onClick={() => {
               setOpenModal(true);
               localStorage.setItem('Unique ID', value.id);
+              console.log('showmeetings', value);
             }}
           >
             <Meeting

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -9,14 +9,17 @@ import {
   query,
   getDocs,
   orderBy,
+  doc,
+  deleteDoc,
 } from '@firebase/firestore';
 import { useState, useEffect } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useRecoilState } from 'recoil';
 import { cardDataState } from './../../states/cardDataState';
 import { mapState } from '@/states/mapState';
 import { titleMainState } from '@/states/titleMainState';
 import { addressMainState } from '@/states/addressMainState';
 import { detailMainState } from '@/states/detailMainState';
+import { usersState } from '@/states/usersState';
 
 export default function MainPage() {
   const title = useRecoilValue(titleMainState);
@@ -24,8 +27,7 @@ export default function MainPage() {
   const detail = useRecoilValue(detailMainState);
   const cardData = useRecoilValue(cardDataState);
   const mapData = useRecoilValue(mapState);
-
-  const [users, setUsers] = useState([]);
+  const [users, setUsers] = useRecoilState(usersState);
 
   const usersCollectionRef = query(
     collection(db, 'makeMeetings'),
@@ -62,7 +64,7 @@ export default function MainPage() {
     <>
       <Banner />
       <SearchFrom {...searchFormProps} />
-      <ShowMeetings users={users} />
+      <ShowMeetings />
     </>
   );
 }

--- a/src/states/deleteUsers.ts
+++ b/src/states/deleteUsers.ts
@@ -1,0 +1,14 @@
+import { atom } from 'recoil';
+import { db } from '@/firebase/firestore/index';
+import { doc, deleteDoc } from '@firebase/firestore';
+
+export const deleteUsers = atom({
+  key: 'deleteUsers',
+  default: async (id) => {
+    // 내가 삭제하고자 하는 db의 컬렉션의 id를 뒤지면서 데이터를 찾는다
+    const userDoc = doc(db, 'makeMeetings', id);
+    // deleteDoc을 이용해서 삭제
+    await deleteDoc(userDoc);
+    localStorage.setItem('Unique ID', null);
+  },
+});

--- a/src/states/usersState.ts
+++ b/src/states/usersState.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const usersState = atom({
+  key: 'usersState',
+  default: [],
+});

--- a/src/utils/MapReading.tsx
+++ b/src/utils/MapReading.tsx
@@ -1,7 +1,11 @@
 import { useSetRecoilState } from 'recoil';
 import { readingMap } from '@/states/readingMap';
 
-export function MapReading({ mapPosition }) {
+interface Props {
+  mapPosition: [];
+}
+
+export function MapReading({ mapPosition }: Props) {
   console.log('MapReading파일', mapPosition);
 
   const setMapData = useSetRecoilState(readingMap);


### PR DESCRIPTION
#119 
✨ 구현 기능 명세
- 카드 클릭후 -> 삭제 버튼 클릭 -> fireStore에 있던 데이터 삭제 + 화면 UI도 삭제되어 카드 사라짐
- 버튼이 2번눌러야 UI가 사라져서 왜그런지 보았더니 => getAfterDelete()가 비동기라 먼저 시도했는데   
   delete도 비동기라 얘보다 먼저 될경우 UI가 사라진걸 인지못해서 생긴 오류였던 것 같습니다.    
  그래서 delete함수 앞에 await을 붙여 순서대로 진행되도록 하였더니 성공하였습니다.

🎁 PR Point
삭제하기 버튼 한번 누를때 바로 db와 UI에 나타나지는지 체크 부탁합니다.

😭 어려웠던 점
fireStore에 있는 데이터를 삭제하는 기능은 바로 구현이 가능했지만, 그걸 화면UI와 바로 연동시켜 동기화 시키는게 어려웠습니다. 상태관리로 해결하였습니다.
카드 클릭시 -> 상태 별도(클릭한 1개의 카드만 랜더링되게)
카드 lists 나열, 삭제할때 => 상태 일치시킴(그래야 카드 lists 나열될때 삭제된것이 반영되어 올라가지고 UI가 그렇게 나타나짐)