### PR TITLE
[fix] 마이페이지 새로고침 후 이미지가 정상적으로 다운로드 안되던 문제 해결

### DIFF
--- a/src/components/ProfileImage/ProfileImage.tsx
+++ b/src/components/ProfileImage/ProfileImage.tsx
@@ -2,13 +2,7 @@ import classes from './ProfileImage.module.scss';
 import { useState, useEffect } from 'react';
 import { getDownloadURL, ref, uploadBytes } from '@firebase/storage';
 import { storage } from '@/firebase/storage/index';
-import {
-  getFirestore,
-  doc,
-  collection,
-  getDoc,
-  setDoc,
-} from '@firebase/firestore';
+import { doc, collection, getDoc, setDoc } from '@firebase/firestore';
 import { auth } from '@/firebase/auth';
 import { db } from '@/firebase/app';
 
@@ -21,17 +15,19 @@ export function ProfileImage() {
   const [imageURL, setImageURL] = useState<string>('');
 
   useEffect(() => {
-    const currentUserUid = auth.currentUser?.uid;
-    if (currentUserUid) {
-      const getUserRef = doc(collection(db, 'users'), currentUserUid);
-      getDoc(getUserRef).then((doc) => {
-        if (doc.exists()) {
-          const userData = doc.data();
-          setImageURL(userData.imageUrl);
-        }
-      });
-    }
-  }, []);
+    const unsub = auth.onAuthStateChanged((user) => {
+      if (user) {
+        const getUserRef = doc(collection(db, 'users'), user.uid);
+        getDoc(getUserRef).then((doc) => {
+          if (doc.exists()) {
+            const userData = doc.data();
+            setImageURL(userData.imageUrl);
+          }
+        });
+      }
+    });
+    return unsub;
+  }, [auth]); // auth 객체를 의존성 배열에 추가
 
   const onImageChange = (
     e: React.ChangeEvent<EventTarget & HTMLInputElement>

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -1,7 +1,25 @@
 import classes from './MyPage.module.scss';
 import { Input, ProfileImage } from '@/components';
+import { useState } from 'react';
 
 export default function MyPage() {
+  const [isEditing, setIsEditing] = useState(true);
+  const [userInfoEdit, setUserInfoEdit] = useState<string>('회원정보수정');
+  const handleEditClick = () => {
+    setIsEditing(!isEditing);
+    if (isEditing) {
+      setUserInfoEdit('수정 완료');
+    } else {
+      setUserInfoEdit('회원정보수정');
+    }
+  };
+
+  // const { displayName, email, phoneNumber } = auth.currentUser;
+  // console.log(displayName, email, phoneNumber);
+  // useEffect(() => {
+  //   const currentUserUid = auth.currentUser
+  // })
+
   return (
     <section className={classes.myPageSection}>
       <div className={classes.myPageContainer}>
@@ -16,7 +34,7 @@ export default function MyPage() {
                   maxWidthValue={290}
                   heightValue={80}
                   labelText="Name"
-                  disabled={true}
+                  disabled={isEditing}
                 />
               </form>
               <form>
@@ -25,7 +43,7 @@ export default function MyPage() {
                   maxWidthValue={290}
                   heightValue={80}
                   labelText="Email"
-                  disabled={true}
+                  disabled={isEditing}
                 />
               </form>
             </div>
@@ -36,7 +54,7 @@ export default function MyPage() {
                   maxWidthValue={290}
                   heightValue={80}
                   labelText="Phone"
-                  disabled={true}
+                  disabled={isEditing}
                 />
               </form>
               <form>
@@ -45,7 +63,7 @@ export default function MyPage() {
                   maxWidthValue={290}
                   heightValue={80}
                   labelText="Address"
-                  disabled={true}
+                  disabled={isEditing}
                 />
               </form>
             </div>
@@ -53,7 +71,9 @@ export default function MyPage() {
         </div>
         <div className={classes.userAbleContainer}>
           <ul>
-            <li className={classes.userAbleItem}>회원정보수정</li>
+            <li className={classes.userAbleItem} onClick={handleEditClick}>
+              {userInfoEdit}
+            </li>
             <li className={classes.userAbleItem}>로그아웃</li>
             <li className={classes.userAbleItem}>회원탈퇴</li>
           </ul>


### PR DESCRIPTION
#121 #122 

✨ 구현 기능 명세
- 마이페이지에서 페이지 새로 고침 후 이미지가 표시가 안되는 문제를 해결했습니다.
- 마이페이지의 input의 속성을 disabled 토글 기능 구현했습니다.

🎁 PR Point


😭 어려웠던 점
- 리액트를 제대로 이해하지 못하고 단순히 구글링을 통하여 코드를 작성하였기에 많이 부족합니다.