### PR TITLE
[feat] 프로필 이미지 업로드 시 currentUser의 photoURL 업데이트 구현

### DIFF
--- a/src/components/ProfileImage/ProfileImage.tsx
+++ b/src/components/ProfileImage/ProfileImage.tsx
@@ -5,6 +5,7 @@ import { storage } from '@/firebase/storage/index';
 import { doc, collection, getDoc, setDoc } from '@firebase/firestore';
 import { auth } from '@/firebase/auth';
 import { db } from '@/firebase/app';
+import { updateProfile } from '@firebase/auth';
 
 function fileInput() {
   const fileInput = document.getElementById('fileInput');
@@ -21,7 +22,7 @@ export function ProfileImage() {
         getDoc(getUserRef).then((doc) => {
           if (doc.exists()) {
             const userData = doc.data();
-            setImageURL(userData.imageUrl);
+            setImageURL(userData.photoURL);
           }
         });
       }
@@ -48,7 +49,10 @@ export function ProfileImage() {
 
         // Firestore에 이미지 URL 저장
         const setUserRef = doc(collection(db, 'users'), currentUserUid);
-        setDoc(setUserRef, { imageUrl: downloadURL }, { merge: true });
+        setDoc(setUserRef, { photoURL: downloadURL }, { merge: true });
+
+        // currentUser에 이미지 URL 업데이트
+        updateProfile(auth.currentUser, { photoURL: downloadURL });
       });
     });
   };


### PR DESCRIPTION
#131 

✨ 구현 기능 명세
![image](https://user-images.githubusercontent.com/89835647/227154444-dc7a7210-3427-4796-bef2-2bc9fc45f2ce.png)
- 프로필 이미지 업로드 시 currentUser의 photoURL이 업데이트 되도록 구현했습니다.
- 기존에 firestore에 저장되던 `imageUrl` 을 `photoURL`로 보기 쉽게 이름을 변경했습니다.

🎁 PR Point


😭 어려웠던 점
