### PR TITLE
[feat] 마이페이지 currentUser와 일부 연동 및 회원탈퇴 구현

### DIFF
--- a/src/components/ProfileImage/ProfileImage.tsx
+++ b/src/components/ProfileImage/ProfileImage.tsx
@@ -52,7 +52,13 @@ export function ProfileImage() {
         setDoc(setUserRef, { photoURL: downloadURL }, { merge: true });
 
         // currentUser에 이미지 URL 업데이트
-        updateProfile(auth.currentUser, { photoURL: downloadURL });
+        updateProfile(auth.currentUser, { photoURL: downloadURL })
+          .then(() => {
+            console.log('프로필 사진 변경 완료!');
+          })
+          .catch((error) => {
+            console.log('프로필 사진 변경 실패!', error);
+          });
       });
     });
   };


### PR DESCRIPTION
#130 #133 

✨ 구현 기능 명세
- `회원정보수정` 시 기존의 Name, Email 값이 currentUser의 `displayName`, `email`에 업데이트 구현
- firestore의 데이터 또한 동시에 업데이트 구현
- `회원 탈퇴` 구현
- `ProfileImage.tsx` 코드 리팩토링

🎁 PR Point
- 회원 가입 할 때 비밀번호를 **`a123456`** 으로 설정하여야 위의 기능들을 사용하실 수 있습니다. (이유는 아래의 **어려웠던 점**에 적었습니다.)

😭 어려웠던 점
- 계정 삭제 및 기존 이메일 변경과 같이 보안에 민감한 작업을 하려면 사용자가 최근에 로그인한 적이 있어야 한다고 합니다. 주어진 [참고](https://firebase.google.com/docs/auth/web/manage-users?hl=ko#re-authenticate_a_user "Firebase 사용자 재인증") 문서를 확인해보시면 됩니다.
- 문서를 참고해서 코드를 짜는 과정에서 계정의 비밀번호 값을 받아와서 넣어줘야 하는데 임시로 **`a123456`** 를 넣었습니다. 아래 사진을 참고하세요.
![image](https://user-images.githubusercontent.com/89835647/227267640-d6f6b7c3-9c29-45eb-84d0-42a82d58d55d.png)
