### PR TITLE
[feat] firestore 연동하여 사용자 재인증 기능 구현

### DIFF
--- a/src/components/ChatDialog/Navbar/Navbar.tsx
+++ b/src/components/ChatDialog/Navbar/Navbar.tsx
@@ -24,7 +24,7 @@ export function Navbar() {
         getDoc(getUserRef).then((doc) => {
           if (doc.exists()) {
             const userData = doc.data();
-            setImageUrl(userData.imageUrl);
+            setImageUrl(userData.photoURL);
           }
         });
       }

--- a/src/components/SignUP/SignUp.tsx
+++ b/src/components/SignUP/SignUp.tsx
@@ -8,6 +8,7 @@ import { doc, setDoc } from '@firebase/firestore';
 import { Link, useNavigate } from 'react-router-dom';
 import { createUserWithEmailAndPassword, updateProfile } from '@firebase/auth';
 import { LogoIconandText } from '../LogoIconandText/LogoIconandText';
+
 export default function SignUp() {
   const [err, setErr] = useState(false);
   const navigate = useNavigate();
@@ -50,6 +51,7 @@ export default function SignUp() {
         email,
         phoneNumber,
         address,
+        password: password,
       });
 
       navigate('/mainPage');

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -91,18 +91,25 @@ export default function MyPage() {
 
     updateEmail(user, email)
       .then(() => {
-        const userProvidedPassword = 'a123456'; // 로그인 된 사용자의 비밀번호를 불러와야함!
-        const credential = EmailAuthProvider.credential(
-          user.email,
-          userProvidedPassword
-        );
-        reauthenticateWithCredential(user, credential)
-          .then(() => {
-            console.log('재인증에 성공하였습니다.');
-          })
-          .catch((error) => {
-            console.log('재인증에 실패하였습니다.', error);
-          });
+        getDoc(getUserRef).then((doc) => {
+          if (doc.exists()) {
+            const userProvidedPassword = doc.data().password;
+            console.log('비밀번호 : ', userProvidedPassword);
+
+            const credential = EmailAuthProvider.credential(
+              user.email,
+              userProvidedPassword
+            );
+            reauthenticateWithCredential(user, credential)
+              .then(() => {
+                console.log('재인증에 성공하였습니다.');
+                alert('회원 정보가 수정되었습니다!');
+              })
+              .catch((error) => {
+                console.log('재인증에 실패하였습니다.', error);
+              });
+          }
+        });
         console.log('사용자 이메일 변경 완료!');
       })
       .catch((error) => {


### PR DESCRIPTION
#92 #135 #136 

✨ 구현 기능 명세
- **Navbar.tsx** -> 프로필 이미지 불러올 때 firestore에서 받아오는 필드 이름 수정 `setImageUrl(userData.photoURL);`
- **SignUp.tsx** -> 회원가입 후 firestore에 password 필드 추가
- 마이페이지에서 회원정보수정 시 사용자 재사용 기능을 firestore에 저장된 password로 해결

🎁 PR Point
- 제 담당 구역이 아닌 혜빈님의 파일(`Navbar.tsx`, `SignUp.tsx`) 2개를 건드렸으니 pull 할 때 유의해주세요!

😭 어려웠던 점
- 유저의 비밀번호를 firestore에 저장을 해도 되는지 정확히는 모르겠다.