### PR TITLE
[feat] 구글 로그인 사용자 정보 불러오기 구현

### DIFF
--- a/src/components/ChatDialog/Navbar/Navbar.tsx
+++ b/src/components/ChatDialog/Navbar/Navbar.tsx
@@ -29,6 +29,8 @@ export function Navbar() {
           if (doc.exists()) {
             const userData = doc.data();
             setImageUrl(userData.photoURL);
+          } else {
+            setImageUrl(user.providerData[0].photoURL);
           }
         });
       }

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -30,6 +30,7 @@ export default function MyPage() {
   const [email, setEmail] = useState('');
   const [phoneNumber, setPhoneNumber] = useState('');
   const [address, setAddress] = useState('');
+  const user = auth.currentUser;
 
   useEffect(() => {
     const unsub = auth.onAuthStateChanged((user) => {
@@ -42,6 +43,11 @@ export default function MyPage() {
             setEmail(userData.email);
             setPhoneNumber(userData.phoneNumber);
             setAddress(userData.address);
+          } else {
+            user.providerData.forEach((profile) => {
+              setName(profile.displayName);
+              setEmail(profile.email);
+            });
           }
         });
       }
@@ -61,14 +67,16 @@ export default function MyPage() {
 
   /* ------------------------------- '회원정보수정' 클릭 ------------------------------ */
   const handleEditClick = () => {
-    setIsEditing(!isEditing);
+    if (user.providerData[0].providerId === 'google.com') {
+      alert('구글 및 카카오 사용자는 회원정보수정이 불가합니다!');
+    } else {
+      setIsEditing(!isEditing);
+    }
   };
 
   /* -------------------------------- 수정 완료 클릭 -------------------------------- */
   const handleSaveClick = () => {
-    const user = auth.currentUser;
     /* ----- Firestore 업데이트 ----- */
-
     const getUserRef = doc(collection(db, 'users'), user.uid);
     setDoc(
       getUserRef,
@@ -97,7 +105,6 @@ export default function MyPage() {
         getDoc(getUserRef).then((doc) => {
           if (doc.exists()) {
             const userProvidedPassword = doc.data().password;
-            console.log('비밀번호 : ', userProvidedPassword);
 
             const credential = EmailAuthProvider.credential(
               user.email,


### PR DESCRIPTION
#141 

✨ 구현 기능 명세
- 사용자가 구글 로그인 시 마이페이지 및 채팅에 정보 불러오기 구현했습니다.
- 단 구글 및 카카오 로그인 사용자는 `회원정보수정`이 불가능하게 구현했습니다.

🎁 PR Point


😭 어려웠던 점
